### PR TITLE
removed import and decorator

### DIFF
--- a/src/controllers/SignInControllerTest.java
+++ b/src/controllers/SignInControllerTest.java
@@ -1,10 +1,9 @@
 package controllers;
 
 import junit.framework.TestCase;
-import org.junit.Test;
+
 
 public class SignInControllerTest extends TestCase {
-    @Test
     public void testAddUser() throws Exception {
 
     }


### PR DESCRIPTION
...since the class extends `TestCase` and no longer needs them

For some reason the import and decorator create errors on my laptop (not my primary device, so not a huge deal). I'm pretty sure they aren't needed anyway since the class extends `TestCase`. Let me know if I'm wrong, or merge at your leisure.
